### PR TITLE
Update esp_modbus version to v2

### DIFF
--- a/dynamic_modbus_master/DynamicModbusMaster.cpp
+++ b/dynamic_modbus_master/DynamicModbusMaster.cpp
@@ -25,20 +25,19 @@
 
 namespace dynamic_modbus_master {
 
-consteval mb_communication_info_t defaultCommInfo() {
-    return {
-            .mode = MB_MODE_RTU,
-            .slave_addr = 0,
-            .parity = UART_PARITY_DISABLE,
-            .dummy_port = 0
-    };
-}
-
 ModbusError DynamicModbusMaster::initialise(ModbusConfig config) {
-    m_config = config;
-    esp_err_t error = mbc_master_init(MB_PORT_SERIAL_MASTER, &m_handle);
+    m_config = config;   
+    mb_communication_info_t commInfo = {};
+    commInfo.ser_opts.port  = m_config.uartPort;
+    commInfo.ser_opts.mode =  m_config.modbusMode;
+    commInfo.ser_opts.baudrate = m_config.baudRate;
+    commInfo.ser_opts.parity = MB_PARITY_NONE;
+    commInfo.ser_opts.uid = 0;
+    
+    esp_err_t error = mbc_master_create_serial(&commInfo, &m_context);
     if (error != ESP_OK) {
-        ESP_LOGE(TAG, "An error occured while trying to initialise the port %s", esp_err_to_name(error));
+        ESP_LOGE(TAG, "An error occurred while trying to create the serial communication: %s",
+                 esp_err_to_name(error));
         if (error == ESP_ERR_NOT_SUPPORTED) {
             return ModbusError::PORT_NOT_SUPPORTED;
         } else if (error == ESP_ERR_INVALID_STATE) {
@@ -46,19 +45,6 @@ ModbusError DynamicModbusMaster::initialise(ModbusConfig config) {
         } else {
             return ModbusError::FAILURE;
         }
-    }
-    
-    mb_communication_info_t commInfo = defaultCommInfo();
-    
-    commInfo.port = m_config.uartPort;
-    commInfo.baudrate = m_config.baudRate;
-    commInfo.mode = m_config.modbusMode;
-    
-    error = mbc_master_setup(&commInfo);
-    if (error != ESP_OK) {
-        ESP_LOGE(TAG, "An error occurred while trying to set up the communication parameters: %s",
-                 esp_err_to_name(error));
-        return ModbusError::INVALID_ARG;
     }
     
     error = uart_set_pin(m_config.uartPort, m_config.txdPin, m_config.rxdPin, m_config.rtsPin, UART_PIN_NO_CHANGE);
@@ -71,7 +57,7 @@ ModbusError DynamicModbusMaster::initialise(ModbusConfig config) {
 }
 
 ModbusError DynamicModbusMaster::start() {
-    esp_err_t error = mbc_master_start();
+    esp_err_t error = mbc_master_start(m_context);
     if (error != ESP_OK) {
         ESP_LOGE(TAG, "An error occurred while starting the Modbus communication stack: %s", esp_err_to_name(error));
         return ModbusError::INVALID_ARG;
@@ -87,12 +73,16 @@ ModbusError DynamicModbusMaster::start() {
 }
 
 ModbusError DynamicModbusMaster::stop() {
-    esp_err_t error = mbc_master_destroy();
+    esp_err_t error = mbc_master_stop(m_context);
     if (error != ESP_OK) {
         ESP_LOGE(TAG, "An error occured while trying to stop and destroy the modbus communication stack %s",
                  esp_err_to_name(error));
         return ModbusError::INVALID_STATE;
     }
     return ModbusError::OK;
+}
+
+void* DynamicModbusMaster::getContext() const {
+    return m_context;
 }
 }

--- a/dynamic_modbus_master/DynamicModbusMaster.cpp
+++ b/dynamic_modbus_master/DynamicModbusMaster.cpp
@@ -25,6 +25,18 @@
 
 namespace dynamic_modbus_master {
 
+DynamicModbusMaster::~DynamicModbusMaster() {
+    // Check if the ModbusMaster was ever intialised.
+    if (!m_context) {
+        return;
+    }
+    esp_err_t error = mbc_master_delete(m_context);
+    if (error != ESP_OK) {
+        ESP_LOGE(TAG, "An error occured while trying to destroy the modbus communication stack %s",
+                 esp_err_to_name(error));
+    }
+}
+
 ModbusError DynamicModbusMaster::initialise(ModbusConfig config) {
     m_config = config;   
     mb_communication_info_t commInfo = {};
@@ -75,7 +87,7 @@ ModbusError DynamicModbusMaster::start() {
 ModbusError DynamicModbusMaster::stop() {
     esp_err_t error = mbc_master_stop(m_context);
     if (error != ESP_OK) {
-        ESP_LOGE(TAG, "An error occured while trying to stop and destroy the modbus communication stack %s",
+        ESP_LOGE(TAG, "An error occured while trying to stop the modbus communication stack %s",
                  esp_err_to_name(error));
         return ModbusError::INVALID_STATE;
     }

--- a/dynamic_modbus_master/SlaveDevice.cpp
+++ b/dynamic_modbus_master/SlaveDevice.cpp
@@ -27,7 +27,7 @@ ModbusError SlaveDevice::sendRequest(mb_param_request_t request, void *data) con
     esp_err_t error;
     do {
         attempts++;
-        error = mbc_master_send_request(&request, data);
+        error = mbc_master_send_request(m_master.getContext(), &request, data);
         if (error != ESP_ERR_TIMEOUT) {
             break;
         }
@@ -43,20 +43,14 @@ ModbusError SlaveDevice::sendRequest(mb_param_request_t request, void *data) con
             case ESP_ERR_NOT_SUPPORTED:
                 return ModbusError::SLAVE_NOT_SUPPORTED;
             case ESP_ERR_INVALID_RESPONSE:
-            case ESP_FAIL:
-                mb_trans_info_t info;
-                mbc_master_get_transaction_info(&info);
-                if (info.exception == 0) {
-                    return ModbusError::INVALID_RESPONSE;
-                }
-                return static_cast<ModbusError>(info.exception + 10);
+                return ModbusError::INVALID_RESPONSE;
             default:
                 return ModbusError::FAILURE;
         }
     }
 }
 
-SlaveDevice::SlaveDevice(uint8_t address, uint8_t retries): m_address(address), m_retries(retries) {
+SlaveDevice::SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster & master): m_address(address), m_retries(retries), m_master(master) {
 }
 
 }

--- a/dynamic_modbus_master/SlaveDevice.cpp
+++ b/dynamic_modbus_master/SlaveDevice.cpp
@@ -50,7 +50,7 @@ ModbusError SlaveDevice::sendRequest(mb_param_request_t request, void *data) con
     }
 }
 
-SlaveDevice::SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster & master): m_address(address), m_retries(retries), m_master(master) {
+SlaveDevice::SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster& master): m_address(address), m_retries(retries), m_master(master) {
 }
 
 }

--- a/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveDevice.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveDevice.cpp
@@ -34,13 +34,13 @@ dynamic_modbus_master::ModbusConfig config {
     .rtsPin = CONFIG_MB_UART_RTS,
     .baudRate = CONFIG_MB_UART_BAUD_RATE,
     #ifdef CONFIG_MB_COMM_MODE_RTU
-    .modbusMode = MB_MODE_RTU,
+    .modbusMode = MB_RTU,
     #elif CONFIG_MB_COMM_MODE_ASCII
-    .modbusMode = MB_MODE_ASCII
+    .modbusMode = MB_ASCII
     #endif
 };
 
-SingleSlaveExampleDevice g_exampleDevice(1, 1);
+SingleSlaveExampleDevice g_exampleDevice(1, 1, master);
 
 extern "C" void app_main() {
     dynamic_modbus_master::ModbusError error = master.initialise(config);

--- a/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.cpp
@@ -21,7 +21,7 @@
 #include "SingleSlaveExampleDevice.h"
 #include <ModbusErrorHelper.h>
 
-SingleSlaveExampleDevice::SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master) : SlaveDevice(address, retries, master){
+SingleSlaveExampleDevice::SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster& master) : SlaveDevice(address, retries, master){
 
 }
 

--- a/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.cpp
@@ -21,7 +21,7 @@
 #include "SingleSlaveExampleDevice.h"
 #include <ModbusErrorHelper.h>
 
-SingleSlaveExampleDevice::SingleSlaveExampleDevice(uint8_t address, uint8_t retries) : SlaveDevice(address, retries){
+SingleSlaveExampleDevice::SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master) : SlaveDevice(address, retries, master){
 
 }
 

--- a/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.h
+++ b/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.h
@@ -25,7 +25,7 @@
 
 class SingleSlaveExampleDevice : private dynamic_modbus_master::slave::SlaveDevice{
 public:
-    SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master);
+    SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster& master);
     
     uint16_t readExampleSingleRegister();
     

--- a/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.h
+++ b/dynamic_modbus_master/examples/SingleSlaveDevice/main/SingleSlaveExampleDevice.h
@@ -25,7 +25,7 @@
 
 class SingleSlaveExampleDevice : private dynamic_modbus_master::slave::SlaveDevice{
 public:
-    SingleSlaveExampleDevice(uint8_t address, uint8_t retries);
+    SingleSlaveExampleDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master);
     
     uint16_t readExampleSingleRegister();
     

--- a/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.cpp
@@ -21,7 +21,7 @@
 #include "AggregateDevice.h"
 #include <ModbusErrorHelper.h>
 
-AggregateDevice::AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master):
+AggregateDevice::AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster& master):
         m_device(address, retries, master) {
 }
 

--- a/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.cpp
@@ -21,8 +21,8 @@
 #include "AggregateDevice.h"
 #include <ModbusErrorHelper.h>
 
-AggregateDevice::AggregateDevice(uint8_t address, uint8_t retries):
-        m_device(address, retries) {
+AggregateDevice::AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master):
+        m_device(address, retries, master) {
 }
 
 uint16_t AggregateDevice::readExampleSingleRegister() {
@@ -106,7 +106,7 @@ void AggregateDevice::writeExampleMultipleCoils(uint16_t coilStates) {
     }
 }
 
-bool SingleSlaveExampleDevice::readDiscreteInput() {
+bool AggregateDevice::readDiscreteInput() {
     dynamic_modbus_master::slave::SlaveReturn<bool> slaveReturn = m_device.readDiscreteInputs<bool>(0);
     if (slaveReturn.error != dynamic_modbus_master::ModbusError::OK) {
         ESP_LOGE("SingleSlaveExampleDevice", "Failed to read Discrete Input %s", dynamic_modbus_master::ModbusErrorHelper::modbusErrorToName(slaveReturn.error).c_str());
@@ -114,7 +114,7 @@ bool SingleSlaveExampleDevice::readDiscreteInput() {
     return slaveReturn.data;
 }
 
-uint16_t SingleSlaveExampleDevice::readInput() {
+uint16_t AggregateDevice::readInput() {
     dynamic_modbus_master::slave::SlaveReturn<uint16_t> slaveReturn = m_device.readInputs<uint16_t>(0);
     if (slaveReturn.error != dynamic_modbus_master::ModbusError::OK) {
         ESP_LOGE("SingleSlaveExampleDevice", "Failed to read Input %s", dynamic_modbus_master::ModbusErrorHelper::modbusErrorToName(slaveReturn.error).c_str());

--- a/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.h
+++ b/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.h
@@ -25,7 +25,7 @@
 
 class AggregateDevice{
 public:
-    AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master);
+    AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster& master);
     
     uint16_t readExampleSingleRegister();
     

--- a/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.h
+++ b/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/AggregateDevice.h
@@ -25,7 +25,7 @@
 
 class AggregateDevice{
 public:
-    AggregateDevice(uint8_t address, uint8_t retries);
+    AggregateDevice(uint8_t address, uint8_t retries, const dynamic_modbus_master::DynamicModbusMaster & master);
     
     uint16_t readExampleSingleRegister();
     

--- a/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/SingleSlaveDeviceAggregate.cpp
+++ b/dynamic_modbus_master/examples/SingleSlaveDeviceAggregate/main/SingleSlaveDeviceAggregate.cpp
@@ -14,13 +14,13 @@ dynamic_modbus_master::ModbusConfig config {
         .rtsPin = CONFIG_MB_UART_RTS,
         .baudRate = CONFIG_MB_UART_BAUD_RATE,
         #ifdef CONFIG_MB_COMM_MODE_RTU
-        .modbusMode = MB_MODE_RTU,
+        .modbusMode = MB_RTU,
         #elif CONFIG_MB_COMM_MODE_ASCII
-        .modbusMode = MB_MODE_ASCII
+        .modbusMode = MB_ASCII
         #endif
 };
 
-AggregateDevice g_exampleDevice(1, 1);
+AggregateDevice g_exampleDevice(1, 1, master);
 
 extern "C" void app_main(void) {
     dynamic_modbus_master::ModbusError error = master.initialise(config);

--- a/dynamic_modbus_master/idf_component.yml
+++ b/dynamic_modbus_master/idf_component.yml
@@ -5,4 +5,4 @@ license: "MIT"
 
 dependencies:
   idf: ">=5.0"
-  espressif/esp-modbus: ">=1.0.17,<2.0"
+  espressif/esp-modbus: ">=2.1.0,<3.0"

--- a/dynamic_modbus_master/include/DynamicModbusMaster.h
+++ b/dynamic_modbus_master/include/DynamicModbusMaster.h
@@ -34,6 +34,11 @@ namespace dynamic_modbus_master {
 class DynamicModbusMaster {
 public:
     /**
+     * @brief Destroys the previously with `initialise` allocated Modbus Master controller.
+     */
+    ~DynamicModbusMaster();
+
+    /**
      * @brief Initialize the Modbus Master controller and set up the communication parameters.
      *
      * @details This function initializes the Modbus Master controller and sets up the communication
@@ -73,7 +78,7 @@ public:
     /**
      * @brief Stop the Modbus communication stack.
      *
-     * @details This function stops the Modbus communication stack by calling the `mbc_master_destroy()` function.
+     * @details This function stops the Modbus communication stack by calling the `mbc_master_stop()` function.
      * If an error occurs during the stop process, an error log is generated using the `ESP_LOGE` macro with the tag
      * "DynamicModbusMaster" and the error name is printed using the `esp_err_to_name()` function. The function returns
      * `ModbusError::INVALID_STATE` to indicate an invalid state error. If the stop process is successful, the

--- a/dynamic_modbus_master/include/DynamicModbusMaster.h
+++ b/dynamic_modbus_master/include/DynamicModbusMaster.h
@@ -88,9 +88,18 @@ public:
      */
     ModbusError stop();
     
+    /**
+     * @brief Get the context object to the Modbus communication stack. Allows to create multiple instances of masters.
+     * 
+     * @note Creating multiple instances was a feature introduced in esp modbus version 2.0, previous version allowed only for one global master to exist even with different protocols.
+     * 
+     * @return Non owning pointer to the context handle, that allows to refer to the initally created Modbus communication stack.
+     */
+    void* getContext() const;
+
 private:
     ModbusConfig m_config;
-    void* m_handle;
+    void* m_context;
 };
 }
 

--- a/dynamic_modbus_master/include/ModbusConfiguration.h
+++ b/dynamic_modbus_master/include/ModbusConfiguration.h
@@ -43,8 +43,8 @@ struct ModbusConfig {
     uint8_t txdPin;
     uint8_t rtsPin;
     uint32_t baudRate;
-    mb_mode_type_t modbusMode;
-    };
+    mb_comm_mode_t modbusMode;
+};
 }
 
 #endif //DYNAMIC_MODBUS_MASTER_MODBUSCONFIGURATION_H

--- a/dynamic_modbus_master/include/ModbusError.h
+++ b/dynamic_modbus_master/include/ModbusError.h
@@ -36,7 +36,7 @@ enum class ModbusError : uint8_t {
     PORT_NOT_SUPPORTED = 5,     //!< This Port is not supported
     INVALID_STATE = 6,          //!< The Modbus Driver or the Device is in an invalid state
     TIMEOUT = 7,                //!< The Driver experienced a timeout
-    FAILURE = 8,                //!< The slave device experienced an undermined failure.
+    FAILURE = 8,                //!< The slave device experienced an undetermined failure.
     // General Exception Codes
     ILLEGAL_FUNCTION = 11,      //!< The received Function code is not available on the target device
     ILLEGAL_DATA_ADDRESS = 12,  //!< The Data Address received is not available

--- a/dynamic_modbus_master/include/SlaveDevice.h
+++ b/dynamic_modbus_master/include/SlaveDevice.h
@@ -44,7 +44,7 @@ public:
      *
      * @details This class provides functionality to initialize and communicate with a slave device using the Modbus protocol.
      */
-    SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster & master);
+    SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster& master);
     
     ~SlaveDevice() override = default;
     
@@ -242,7 +242,7 @@ public:
 private:
     uint8_t m_address;
     uint8_t m_retries;
-    const DynamicModbusMaster & m_master;
+    const DynamicModbusMaster& m_master;
     
     /**
      * @brief Helper function to send a modbus request

--- a/dynamic_modbus_master/include/SlaveDevice.h
+++ b/dynamic_modbus_master/include/SlaveDevice.h
@@ -22,6 +22,7 @@
 #define DYNAMIC_MODBUS_MASTER_SLAVEDEVICE_H
 #include "ModbusData.hpp"
 #include <ModbusError.h>
+#include <DynamicModbusMaster.h>
 #include <esp_modbus_master.h>
 #include <SlaveDeviceIfc.h>
 
@@ -43,7 +44,7 @@ public:
      *
      * @details This class provides functionality to initialize and communicate with a slave device using the Modbus protocol.
      */
-    SlaveDevice(uint8_t address, uint8_t retries);
+    SlaveDevice(uint8_t address, uint8_t retries, const DynamicModbusMaster & master);
     
     ~SlaveDevice() override = default;
     
@@ -241,6 +242,7 @@ public:
 private:
     uint8_t m_address;
     uint8_t m_retries;
+    const DynamicModbusMaster & m_master;
     
     /**
      * @brief Helper function to send a modbus request


### PR DESCRIPTION
Updated the internal `espressif/esp-modbus: ">=2.1.0,<3.0"` dependency to version 2.1. This allows future versions of the library to create multiple masters, because the returned context object from the create method is now used to call methods. Instead of using a global instance.
